### PR TITLE
Add link to Laravel package for Phumbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ echo $thumbnailUrlFactory
 
 Add `99designs/phumbor` as a dependency in [`composer.json`][3].
 
+A [Laravel 4 package](https://github.com/ceejayoz/laravel-phumbor) is available.
 
 ## License
 


### PR DESCRIPTION
I've written a Laravel 4 package that provides a Phumbor facade. I suggest a link in the 'installation' section of the readme.
