### PR TITLE
meta command moved at first place in commands array

### DIFF
--- a/lib/Thumbor/Url/CommandSet.php
+++ b/lib/Thumbor/Url/CommandSet.php
@@ -113,6 +113,9 @@ class CommandSet
     public function toArray()
     {
         $commands = array();
+        
+        if ($this->metadataOnly)
+            $commands []= 'meta';
 
         $maybeAppend = function ($command) use (&$commands) {
             if ($command) $commands []= (string) $command;
@@ -132,9 +135,6 @@ class CommandSet
             $filters = 'filters:' . implode(':', $this->filters);
             $commands []= $filters;
         }
-
-        if ($this->metadataOnly)
-            $commands []= 'metadata';
 
         return $commands;
     }


### PR DESCRIPTION
When using metadataOnly() I was getting 404 for generated url. Problem was the wrong order of commands that caused sign method in Url class to create wrong hash_hmac. Also changed the word 'metadata' to just 'meta', according to thumbor doc.
