### PR TITLE
changes encoding function

### DIFF
--- a/lib/Thumbor/Url.php
+++ b/lib/Thumbor/Url.php
@@ -37,7 +37,7 @@ class Url
      */
     public function stringify($server, $secret, $original, $commands)
     {
-        $original = urlencode($original);
+        $original = rawurlencode($original);
         $commandPath = implode('/', $commands);
         $signature = $secret ? self::sign("$commandPath/$original", $secret) : 'unsafe';
 


### PR DESCRIPTION
Hi, 
I'm experiencing an issue due to spaces in my images path. Space is encoded as + but I get a 404. If it gets encoded as %20 everything works fine.

What do you think?
