### PR TITLE
URL encode the original image

### DIFF
--- a/lib/Thumbor/Url.php
+++ b/lib/Thumbor/Url.php
@@ -38,14 +38,15 @@ class Url
     public function stringify($server, $secret, $original, $commands)
     {
         $commandPath = implode('/', $commands);
-        $signature = $secret ? self::sign("$commandPath/$original", $secret) : 'unsafe';
+        $encoded = urlencode(urldecode($original));
+        $signature = $secret ? self::sign("$commandPath/$encoded", $secret) : 'unsafe';
 
         return sprintf(
             '%s/%s/%s/%s',
             $server,
             $signature,
             $commandPath,
-            $original
+            $encoded
         );
     }
 

--- a/tests/Thumbor/Url/BuilderTest.php
+++ b/tests/Thumbor/Url/BuilderTest.php
@@ -36,7 +36,7 @@ class BuilderTest extends TestCase
             ->smartCrop(true)
             ->addFilter('brightness', 42);
 
-        $expected = 'http://thumbor.example.com/dgzk7MVde2RUq5Hbq40FvfRdno0=/fit-in/320x240/smart/filters:brightness(42)/http://example.com/llamas.jpg';
+        $expected = 'http://thumbor.example.com/y8O2zwNvj1D6rv1qpaHTUiZjgG0=/fit-in/320x240/smart/filters:brightness(42)/http%3A%2F%2Fexample.com%2Fllamas.jpg';
 
         $this->assertEquals($expected, $url);
     }

--- a/tests/Thumbor/UrlTest.php
+++ b/tests/Thumbor/UrlTest.php
@@ -27,7 +27,37 @@ class UrlTest extends TestCase
         );
 
         $this->assertEquals(
-            'http://thumbor-server:8888/bDv76lTvUdX6vORS96scx7P185c=/fit-in/560x420/filters:fill(green)/my/big/image.jpg',
+            'http://thumbor-server:8888/-qITCsYPvj2Lt0ivIX1eXHhGFOM=/fit-in/560x420/filters:fill(green)/my%2Fbig%2Fimage.jpg',
+            "$url"
+        );
+    }
+
+    public function testToStringWithAbsoluteUrl()
+    {
+        $url = new Url(
+            'http://thumbor-server:8888',
+            'MY_SECURE_KEY',
+            'http://example.org/my/big/image.jpg',
+            array('fit-in', '560x420', 'filters:fill(green)')
+        );
+
+        $this->assertEquals(
+            'http://thumbor-server:8888/RbTNMbAMGJBS3c3oiy57VaIqs64=/fit-in/560x420/filters:fill(green)/http%3A%2F%2Fexample.org%2Fmy%2Fbig%2Fimage.jpg',
+            "$url"
+        );
+    }
+
+    public function testOriginalUrlIsNotDoubleEncoded()
+    {
+        $url = new Url(
+            'http://thumbor-server:8888',
+            'MY_SECURE_KEY',
+            'http%3A%2F%2Fexample.org%2Fmy%2Fbig%2Fimage.jpg',
+            array('fit-in', '560x420', 'filters:fill(green)')
+        );
+
+        $this->assertEquals(
+            'http://thumbor-server:8888/RbTNMbAMGJBS3c3oiy57VaIqs64=/fit-in/560x420/filters:fill(green)/http%3A%2F%2Fexample.org%2Fmy%2Fbig%2Fimage.jpg',
             "$url"
         );
     }


### PR DESCRIPTION
This fix addresses #13 

Without url encoding thumbor will treat the generated url as malformed.

eg. 
This is invalid:
http://thumbor.example.com/{hash}=/fit-in/320x240/http://example.com/llamas.jpg

This is valid:
http://thumbor.example.com/{hash}=/fit-in/320x240/http%3A%2F%2Fexample.com%2Fllamas.jpg'

@harto @lwc 
