### PR TITLE
Added clearFilters method to allow re-use of same initialized image

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "99designs/phumbor",
-    "description": "A minimal Thumbor library for PHP",
-    "homepage": "https://github.com/99designs/phumbor",
+    "name": "virtuman/phumbor",
+    "description": "A minimal Thumbor library for PHP, added clear method",
+    "homepage": "https://github.com/virtuman/phumbor",
     "keywords": [
         "php", "thumbor", "thumbnails", "99designs"
     ],

--- a/lib/Thumbor/Url/CommandSet.php
+++ b/lib/Thumbor/Url/CommandSet.php
@@ -106,6 +106,14 @@ class CommandSet
     }
 
     /**
+     * Reset all currently applied filters to allow re-usage of init'ed image
+     */
+    public function clearFilters()
+    {
+    	$this->filters = array();
+    }
+    
+    /**
      * Specify that JSON metadata should be returned instead of the thumbnailed
      * image.
      * @param bool $metadataOnly


### PR DESCRIPTION
Added clearFilters method to reset all currently applied filters to allow re-usage of init'ed image and object. This allows to create output for same image with different filters applied to it.