### PR TITLE
Nette Frameworks in it's config file which generates DI Container is …

### DIFF
--- a/lib/Thumbor/Url/BuilderFactory.php
+++ b/lib/Thumbor/Url/BuilderFactory.php
@@ -25,8 +25,8 @@ class BuilderFactory
     private $secret;
 
     /**
-     * @param $server
-     * @param null $secret
+     * @param string $server
+     * @param string|null $secret
      * @return BuilderFactory
      */
     public static function construct($server, $secret=null)
@@ -35,9 +35,8 @@ class BuilderFactory
     }
 
     /**
-     * BuilderFactory constructor.
-     * @param $server
-     * @param null $secret
+     * @param string $server
+     * @param string|null $secret
      */
     public function __construct($server, $secret=null)
     {
@@ -46,7 +45,7 @@ class BuilderFactory
     }
 
     /**
-     * @param $original
+     * @param string $original
      * @return Builder
      */
     public function url($original)

--- a/lib/Thumbor/Url/BuilderFactory.php
+++ b/lib/Thumbor/Url/BuilderFactory.php
@@ -24,17 +24,31 @@ class BuilderFactory
     private $server;
     private $secret;
 
+    /**
+     * @param $server
+     * @param null $secret
+     * @return BuilderFactory
+     */
     public static function construct($server, $secret=null)
     {
         return new self($server, $secret);
     }
 
+    /**
+     * BuilderFactory constructor.
+     * @param $server
+     * @param null $secret
+     */
     public function __construct($server, $secret=null)
     {
         $this->server = $server;
         $this->secret = $secret;
     }
 
+    /**
+     * @param $original
+     * @return Builder
+     */
     public function url($original)
     {
         return Builder::construct($this->server, $this->secret, $original);


### PR DESCRIPTION
Nette Frameworks (nette.org) in it's config file which generates DI Container from (neon file - similar to yaml) is using annotations which are missing here. I hope it would not be an issue to have them here.