### PR TITLE
Fix UrlBuilder to work better with PHP clone operator

### DIFF
--- a/lib/Thumbor/Url/Builder.php
+++ b/lib/Thumbor/Url/Builder.php
@@ -55,6 +55,11 @@ class Builder
         $this->commands = new CommandSet();
     }
 
+    public function __clone()
+    {
+        $this->commands = clone $this->commands;
+    }
+
     // Proxy remaining method calls to CommandSet
     public function __call($method, $args)
     {


### PR DESCRIPTION
Being able to clone the url builder instance can be useful in certain situations. e.g.

```php
$builder = Thumbor\Url\Builder::construct($server, $secret, 'http://a.com/b.jpg');

$a = clone $builder;
$a->addFilter('fill', 'green');

$b = clone $builder;
$b->addFilter('fill', 'red');
```

This PR makes this possible by ensuring the `$commands` instance variable is also cloned correctly.