### PR TITLE
Add ability to use base image url in builder factory

### DIFF
--- a/lib/Thumbor/Url/BuilderFactory.php
+++ b/lib/Thumbor/Url/BuilderFactory.php
@@ -25,6 +25,11 @@ class BuilderFactory
     private $secret;
 
     /**
+     * @var string
+     */
+    private $baseUrl;
+
+    /**
      * @param string $server
      * @param string|null $secret
      * @return BuilderFactory
@@ -45,11 +50,24 @@ class BuilderFactory
     }
 
     /**
+     * @param $url
+     * @return $this
+     */
+    public function baseUrl($url)
+    {
+        $this->baseUrl = $url;
+        return $this;
+    }
+
+    /**
      * @param string $original
      * @return Builder
      */
     public function url($original)
     {
+        if (!is_null($this->baseUrl)) {
+            $original = "{$this->baseUrl}/$original";
+        }
         return Builder::construct($this->server, $this->secret, $original);
     }
 }

--- a/tests/Thumbor/Url/BuilderFactoryTest.php
+++ b/tests/Thumbor/Url/BuilderFactoryTest.php
@@ -19,4 +19,17 @@ class BuilderFactoryTest extends TestCase
 
         $this->assertEquals($expected, $builder);
     }
+
+    public function testBaseUrl()
+    {
+        $server = 'http://thumbor.example.com';
+        $secret = 'butts';
+        $baseUrl = 'http://example.com';
+        $original = 'llamas.jpg';
+
+        $builder = BuilderFactory::construct($server, $secret)->baseUrl($baseUrl)->url($original);
+        $expected = Builder::construct($server, $secret, "$baseUrl/$original");
+
+        $this->assertEquals($expected, $builder);
+    }
 }


### PR DESCRIPTION
Hi. I have a case, when I should concatenate base url for images with relative path for generating thumbor link. And I want to have ability set base url inside Service Provider and call 'url' method of BuilderFactory with relative path to image.